### PR TITLE
Update to latest Ollama request messages fields option and other misc

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -25,10 +25,10 @@
       "identifier": "model",
       "type": "text",
       "title": "模型",
-      "defaultValue": "llama2",
+      "defaultValue": "llama3",
       "textConfig": {
         "type": "visible",
-        "placeholderText": "llama2"
+        "placeholderText": "llama3"
       }
     },
     {

--- a/src/main.js
+++ b/src/main.js
@@ -107,10 +107,6 @@ function buildRequestBody(model, query) {
     stream: false,
     messages: [
       {
-        role: 'assistant',
-        content: systemPrompt,
-      },
-      {
         role: 'user',
         content: userPrompt,
       },
@@ -197,7 +193,7 @@ function translate(query) {
   const baseUrl = apiUrl || 'http://localhost:11434';
   const apiUrlPath = '/api/chat';
 
-  const modelValue = 'llama2';
+  const modelValue = $option.model ?? "llama3";
 
   const body = buildRequestBody(modelValue, query);
 


### PR DESCRIPTION
Multiple messages fields would cause error response againt Ollama service, thus this pull request is mainly to eliminate unnecessary fields to make the plugin work again.

And another trivial change is to make the plugin get user preferred model from $options instead of hardcoded "llama2".